### PR TITLE
header: add li.offline style

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -20,6 +20,7 @@
         main>.container {
             padding-top: 60px;
         }
+        li.offline { color: #c0c0c0; }
         /*.container {
             padding-top: 10px;
         }*/


### PR DESCRIPTION
The players.php page needs at least the li.offline style from the commented-out g7.css to look correct.